### PR TITLE
chore: Upgrade Python and dependencies

### DIFF
--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -11,7 +11,7 @@ jobs:
     - name: Set up Python 3.12
       uses: actions/setup-python@v5
       with:
-        python-version: "3.12"
+        python-version: "3.14"
     - name: Install dependencies
       env:
         REQUIREMENTS_FILE: lint
@@ -34,7 +34,7 @@ jobs:
     - name: Set up Python 3.12
       uses: actions/setup-python@v5
       with:
-        python-version: "3.12"
+        python-version: "3.14"
     - name: Install dependencies
       env:
         REQUIREMENTS_FILE: typecheck
@@ -73,7 +73,7 @@ jobs:
     - name: Set up Python 3.12
       uses: actions/setup-python@v5
       with:
-        python-version: "3.12"
+        python-version: "3.14"
     - name: Install dependencies
       env:
         REQUIREMENTS_FILE: test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.14-alpine AS build
-RUN python3.14 -m pip install --upgrade pip setuptools wheel
+RUN python3.14 -m pip install --upgrade pip "setuptools>=83.0.0" "wheel>=0.47.0"
 
 WORKDIR /app
 COPY setup.cfg .

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,27 +20,27 @@ project_urls =
 package_dir =
     = src
 packages = find_namespace:
-python_requires = >=3.12
+python_requires = >=3.14
 setup_requires =
-    setuptools>=60.2.0
-    wheel>=0.37.1
+    setuptools>=83.0.0
+    wheel>=0.47.0
 install_requires =
-    SQLAlchemy>=2.0.29
-    aiohttp>=3.9.3
-    psycopg2-binary>=2.9.9
+    SQLAlchemy>=2.0.51
+    aiohttp>=3.14.1
+    psycopg2-binary>=2.9.12
 zip_safe = false
 include_package_data = true
 
 [options.extras_require]
 dev =
 lint =
-    flake8>=7.0.0
+    flake8>=7.3.0
 typecheck =
-    mypy>=1.9.0
-    sqlalchemy[mypy]>=2.0.29
+    mypy>=2.3.0
+    sqlalchemy[mypy]>=2.0.51
 test =
-    pytest>=8.1.1
-    pytest-asyncio>=0.23.6
+    pytest>=9.1.1
+    pytest-asyncio>=1.4.0
 [mypy]
 plugins = sqlalchemy.ext.mypy.plugin
 ignore_missing_imports = true


### PR DESCRIPTION
## Summary

- Raise the supported runtime from Python 3.13 to Python 3.14.
- Upgrade SQLAlchemy, aiohttp, psycopg2, and packaging dependencies.
- Upgrade pytest, pytest-asyncio, mypy, and flake8.
- Align the Docker image and GitHub Actions environment with Python 3.14.

## Test plan

- [x] Install runtime and development dependencies on Python 3.14
- [x] Run flake8 and mypy
- [x] Build the wheel without resolving dependencies
- [x] GitHub Actions lint, type-check, and database-backed tests
